### PR TITLE
Fix and improve jupyter notebook rendering in dark theme

### DIFF
--- a/assets/css/jupyter-monokai.css
+++ b/assets/css/jupyter-monokai.css
@@ -3756,3 +3756,7 @@ div#maintoolbar {
 #header-container {
   display: none !important;
 }
+
+img {
+  opacity: 0.8; /* Avoid rendered images being too bright in dark mode */
+}

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -33,7 +33,7 @@ $(document).ready(function () {
 
   // add css to jupyter notebooks
   const cssLink = document.createElement("link");
-  cssLink.href = "../css/jupyter.css";
+  cssLink.href = "/assets/css/jupyter.css";
   cssLink.rel = "stylesheet";
   cssLink.type = "text/css";
 


### PR DESCRIPTION
- `./css/jupyter.css` does not seem to work correctly for my site. Changes to `/assets/css/jupyter.css`.
- Give image some opacity in monokai theme for Jupyter notebooks (i.e. the dark theme) to avoid rendering images being too bright.